### PR TITLE
Added possibility to show minutes and seconds as the remaining time

### DIFF
--- a/SRCountdownTimer/SRCountdownTimer.swift
+++ b/SRCountdownTimer/SRCountdownTimer.swift
@@ -48,6 +48,9 @@ public class SRCountdownTimer: UIView {
     private var totalTime: TimeInterval = 1
     private var elapsedTime: TimeInterval = 0
     private let fireInterval: TimeInterval = 0.01 // ~60 FPS
+    
+    // use minutes and seconds for presentation
+    private var useMinutesAndSecondsRepresentation = false
 
     private lazy var counterLabel: UILabel = {
         let label = UILabel()
@@ -70,7 +73,11 @@ public class SRCountdownTimer: UIView {
                 if let text = timerFinishingText, currentCounterValue == 0 {
                     counterLabel.text = text
                 } else {
-                    counterLabel.text = "\(currentCounterValue)"
+                    if useMinutesAndSecondsRepresentation {
+                        counterLabel.text = getMinutesAndSeconds(remainingSeconds: currentCounterValue)
+                    } else {
+                        counterLabel.text = "\(currentCounterValue)"
+                    }
                 }
             }
 
@@ -184,5 +191,15 @@ public class SRCountdownTimer: UIView {
         timer?.invalidate()
         
         delegate?.timerDidEnd?()
+    }
+    
+    /**
+     * Calculate value in minutes and seconds and return it as String
+     */
+    private func getMinutesAndSeconds(remainingSeconds: Int) -> (String) {
+        let minutes = remainingSeconds / 60
+        let seconds = remainingSeconds - minutes * 60
+        let secondString = seconds < 10 ? "0" + seconds.description : seconds.description
+        return minutes.description + ":" + secondString
     }
 }

--- a/SRCountdownTimer/SRCountdownTimer.swift
+++ b/SRCountdownTimer/SRCountdownTimer.swift
@@ -43,14 +43,14 @@ public class SRCountdownTimer: UIView {
     public var timerFinishingText: String?
 
     public weak var delegate: SRCountdownTimerDelegate?
+    
+    // use minutes and seconds for presentation
+    public var useMinutesAndSecondsRepresentation = false
 
     private var timer: Timer?
     private var totalTime: TimeInterval = 1
     private var elapsedTime: TimeInterval = 0
     private let fireInterval: TimeInterval = 0.01 // ~60 FPS
-    
-    // use minutes and seconds for presentation
-    private var useMinutesAndSecondsRepresentation = false
 
     private lazy var counterLabel: UILabel = {
         let label = UILabel()

--- a/SRCountdownTimerExample/SRCountdownTimerExample/ViewController.swift
+++ b/SRCountdownTimerExample/SRCountdownTimerExample/ViewController.swift
@@ -15,11 +15,16 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        // uncomment this line if would like to see a minute and second representation of the remaining time
+        // (rather than just a second representation
+        //countdownTimer.useMinutesAndSecondsRepresentation = true
+        
         countdownTimer.labelFont = UIFont(name: "HelveticaNeue-Light", size: 50.0)
         countdownTimer.labelTextColor = UIColor.red
         countdownTimer.timerFinishingText = "End"
         countdownTimer.lineWidth = 4
-        countdownTimer.start(beginingValue: 10, interval: 1)
+        countdownTimer.start(beginingValue: 15, interval: 1)
+        
     }
 }
 


### PR DESCRIPTION
I have added the possibility to choose between two modes via a Boolean variable called "useMinutesAndSecondsRepresentation" which is per default false. If the user decides to set this variable to true the timer will show the remaining time as minutes and seconds (rather than just seconds as before). I have also added a commented line to the example which the user can uncomment in order to see this new feature working. 