### PR TITLE
Add sender parameter to the delegate.

### DIFF
--- a/SRCountdownTimer/SRCountdownTimer.swift
+++ b/SRCountdownTimer/SRCountdownTimer.swift
@@ -25,11 +25,11 @@
 import UIKit
 
 @objc public protocol SRCountdownTimerDelegate: class {
-    @objc optional func timerDidUpdateCounterValue(newValue: Int)
-    @objc optional func timerDidStart()
-    @objc optional func timerDidPause()
-    @objc optional func timerDidResume()
-    @objc optional func timerDidEnd()
+    @objc optional func timerDidUpdateCounterValue(sender: SRCountdownTimer, newValue: Int)
+    @objc optional func timerDidStart(sender: SRCountdownTimer)
+    @objc optional func timerDidPause(sender: SRCountdownTimer)
+    @objc optional func timerDidResume(sender: SRCountdownTimer)
+    @objc optional func timerDidEnd(sender: SRCountdownTimer)
 }
 
 public class SRCountdownTimer: UIView {
@@ -83,7 +83,7 @@ public class SRCountdownTimer: UIView {
                 }
             }
 
-            delegate?.timerDidUpdateCounterValue?(newValue: currentCounterValue)
+            delegate?.timerDidUpdateCounterValue?(sender: self, newValue: currentCounterValue)
         }
     }
 
@@ -155,7 +155,7 @@ public class SRCountdownTimer: UIView {
 
         RunLoop.main.add(timer!, forMode: .commonModes)
 
-        delegate?.timerDidStart?()
+        delegate?.timerDidStart?(sender: self)
     }
 
     /**
@@ -164,7 +164,7 @@ public class SRCountdownTimer: UIView {
     public func pause() {
         timer?.fireDate = Date.distantFuture
 
-        delegate?.timerDidPause?()
+        delegate?.timerDidPause?(sender: self)
     }
 
     /**
@@ -173,7 +173,7 @@ public class SRCountdownTimer: UIView {
     public func resume() {
         timer?.fireDate = Date()
 
-        delegate?.timerDidResume?()
+        delegate?.timerDidResume?(sender: self)
     }
     
     /**
@@ -183,7 +183,7 @@ public class SRCountdownTimer: UIView {
         self.currentCounterValue = 0
         timer?.invalidate()
         
-        delegate?.timerDidEnd?()
+        delegate?.timerDidEnd?(sender: self)
     }
     
     /**

--- a/SRCountdownTimerTests/SRCountdownTimerTests.swift
+++ b/SRCountdownTimerTests/SRCountdownTimerTests.swift
@@ -87,17 +87,21 @@ class SRCountdownTimerTests: XCTestCase {
 }
 
 extension SRCountdownTimerTests: SRCountdownTimerDelegate {
-    func timerDidEnd() {
-        expectationTimerDidStop?.fulfill()
-        timerDidStopFlag = true
+    func timerDidEnd(sender: SRCountdownTimer) {
+        if sender === timer {
+            expectationTimerDidStop?.fulfill()
+            timerDidStopFlag = true
+        }
     }
     
-    func timerDidUpdateCounterValue(newValue: Int) {
-        print (newValue)
-        updatedCounterValue.append(newValue)
-        
-        if newValue == 1 && expectationTimerDidUpdate != nil {
-            expectationTimerDidUpdate?.fulfill()
+    func timerDidUpdateCounterValue(sender: SRCountdownTimer, newValue: Int) {
+        if sender === timer {
+            print (newValue)
+            updatedCounterValue.append(newValue)
+            
+            if newValue == 1 && expectationTimerDidUpdate != nil {
+                expectationTimerDidUpdate?.fulfill()
+            }
         }
     }
 }


### PR DESCRIPTION
Add sender parameter to the delegate, for use multiple timer in a calss. Such as fry timer, egg timer, pizza timer, ... in a Cook class.