### PR TITLE
Fix for Swift 4.2

### DIFF
--- a/SRCountdownTimer/SRCountdownTimer.swift
+++ b/SRCountdownTimer/SRCountdownTimer.swift
@@ -153,7 +153,7 @@ public class SRCountdownTimer: UIView {
         timer?.invalidate()
         timer = Timer(timeInterval: fireInterval, target: self, selector: #selector(SRCountdownTimer.timerFired(_:)), userInfo: nil, repeats: true)
 
-        RunLoop.main.add(timer!, forMode: .commonModes)
+        RunLoop.main.add(timer!, forMode: .common)
 
         delegate?.timerDidStart?()
     }


### PR DESCRIPTION
`commonModes` was renamed to `RunLoop.Mode.common` in Swift 4.2