### PR TITLE
Fixed issue with timer movement direction

### DIFF
--- a/SRCountdownTimer/SRCountdownTimer.swift
+++ b/SRCountdownTimer/SRCountdownTimer.swift
@@ -127,7 +127,7 @@ public class SRCountdownTimer: UIView {
             radius: radius,
             startAngle: currentAngle - .pi / 2,
             endAngle: .pi * 2 - .pi / 2,
-            clockwise: false)
+            clockwise: !moveClockWise)
         context?.setStrokeColor(lineColor.cgColor)
         context?.strokePath()
 
@@ -138,7 +138,7 @@ public class SRCountdownTimer: UIView {
             radius: radius,
             startAngle: -.pi / 2,
             endAngle: currentAngle - .pi / 2,
-            clockwise: false)
+            clockwise: !moveClockWise)
         context?.setStrokeColor(trailLineColor.cgColor)
         context?.strokePath()
     }


### PR DESCRIPTION
With changing line movement from default (clockwise) to opposite, there was a bug that prevented line from drawing correctly (it never changed from 100% state)